### PR TITLE
Minor cleanup

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: ruamel_yaml
-  version: 0.11.7
+  version: {{ version }}
 
 source:
   fn: ruamel_yaml-{{ version }}.tar.gz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a705cb1f0eea40d17da713161af3ed00ffa724e401fbd49f35f979bd9529cd00
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
 about:
   home: https://bitbucket.org/kalefranz/yaml
   license: MIT
+  license_family: MIT
   summary: A fork of ruamel.yaml.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
 
   run:
     - python
-    - setuptools
     - yaml
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - python
     - setuptools
+    - cython
     - yaml
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ about:
   home: https://bitbucket.org/kalefranz/yaml
   license: MIT
   license_family: MIT
+  license_file: LICENSE
   summary: A fork of ruamel.yaml.
 
 extra:


### PR DESCRIPTION
* Template out the version in one more place.
* Update the license metadata.
* Package the license file.
* Drop `setuptools` from `run`.
  * Was only added to match `ruamel.yaml`, but after careful inspection this seems unnecessary. ( https://github.com/conda-forge/ruamel.yaml-feedstock/issues/9 )
* Add `cython` to `build`. (optional, but nice)
* Bump the build number.