### PR TITLE
Require equivalent MSVC yaml build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,11 +32,11 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -47,7 +47,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,10 @@ source:
 build:
   number: 0
   no_link: .*\.(pyd|dll)  # [win]
+  features:
+    - vc9     [win and py27]
+    - vc10    [win and py34]
+    - vc14    [win and (py35 or py36)]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,9 @@ build:
   number: 1
   no_link: .*\.(pyd|dll)  # [win]
   features:
-    - vc9     [win and py27]
-    - vc10    [win and py34]
-    - vc14    [win and (py35 or py36)]
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and (py35 or py36)]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b78d394e192b6d0911bd59f794ceea88143fac4e373b76ed7e48143a2a29b33c
 
 build:
-  number: 0
+  number: 1
   no_link: .*\.(pyd|dll)  # [win]
   features:
     - vc9     [win and py27]


### PR DESCRIPTION
Currently, this build pulls in whatever `yaml.dll` is in the environment's
Library\bin directory (from the `yaml` package). This by default is the VS2008 
/ VC9 build, which unnecessarily introduces a dependency on VC9 and isn't 
directly covered by conda. This violates the expectation the the necessary
DLLs for conda are included within the environment.

Installed locally and tested the MSVC version, ran conda-smithy rerender, 
and bumped the build version.