### PR TITLE
reintroduce updated test patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://bitbucket.org/ruamel/yaml/get/{{ version }}.tar.gz
   sha256: 256fe31c23003339f7a056a68ffdd7a55544ae1195a9a1f155effe51e46d175f
+  patches:
+    - ordereddict_test.patch
 
 build:
   number: 0

--- a/recipe/ordereddict_test.patch
+++ b/recipe/ordereddict_test.patch
@@ -1,0 +1,13 @@
+--- a/_test/test_yamlfile.py
++++ b/_test/test_yamlfile.py
+@@ -58,9 +58,9 @@
+     @pytest.mark.skipif(sys.version_info >= (3, 0) or
+                         platform.python_implementation() != "CPython",
+                         reason="ruamel.yaml not available")
+     def test_dump_ruamel_ordereddict(self):
+-        from ruamel.ordereddict import ordereddict
++        ordereddict = pytest.importorskip('ruamel.ordereddict').ordereddict
+         import ruamel.yaml  # NOQA
+         # OrderedDict mapped to !!omap
+         x = ordereddict([('a', 1), ('b', 2)])
+         res = ruamel.yaml.dump(x,


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

Followup on gh-23 in which I removed the old patch.
The patch originally came from `anaconda-recipes` and I assume exists because there is no `defaults::ruamel.ordereddict`.
Technically the patch isn't needed on conda-forge because
- the tests aren't run at all, and
- there is `conda-forge::ruamel.ordereddict` which we could add as a Python 2-only test requirement if we were to run the tests.

No need to bump the build number since the test files do not impact the built package.